### PR TITLE
WIP: Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,33 @@ jobs:
     - name: make
       working-directory: build
       run: make
+
+  build_ubuntu_cmake_without_ssl:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DWITHOUT_SSL=ON
+    - name: make
+      working-directory: build
+      run: make
+
+  build_ubuntu_cmake_without_xml:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DWITHOUT_XML=ON
+    - name: make
+      working-directory: build
+      run: make


### PR DESCRIPTION
Update the CI to also build without XML or without SSL support, to ensure this doesn't broken with a future change, like this was the case in the past (see issue https://github.com/cinecert/asdcplib/issues/80)